### PR TITLE
Remove gradient

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,4 +7,5 @@ version = "0.2.0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
+LinearAlgebra = "1.2"
 julia = "1.2"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProximalCore"
 uuid = "dc4f5ac2-75d1-4f31-931e-60435d74994b"
 authors = ["Lorenzo Stella <lorenzostella@gmail.com>"]
-version = "1.0.0"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProximalCore"
 uuid = "dc4f5ac2-75d1-4f31-931e-60435d74994b"
 authors = ["Lorenzo Stella <lorenzostella@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ProximalCore"
 uuid = "dc4f5ac2-75d1-4f31-931e-60435d74994b"
 authors = ["Lorenzo Stella <lorenzostella@gmail.com>"]
-version = "0.2.0"
+version = "1.0.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ProximalCore.jl
+++ b/src/ProximalCore.jl
@@ -9,36 +9,6 @@ is_generalized_quadratic(::Type) = false
 is_generalized_quadratic(::T) where T = is_generalized_quadratic(T)
 
 """
-    gradient!(y, f, x)
-
-In-place gradient (and value) of `f` at `x`.
-
-The gradient is written to the (pre-allocated) array `y`, which should have the same shape/size as `x`.
-
-Returns the value `f` at `x`.
-
-See also: [`gradient`](@ref).
-"""
-gradient!
-
-"""
-    gradient(f, x)
-
-Gradient (and value) of `f` at `x`.
-
-Return a tuple `(y, fx)` consisting of
-- `y`: the gradient of `f` at `x`
-- `fx`: the value of `f` at `x`
-
-See also: [`gradient!`](@ref).
-"""
-function gradient(f, x)
-    y = similar(x)
-    fx = gradient!(y, f, x)
-    return y, fx
-end
-
-"""
     prox!(y, f, x, gamma=1)
 
 In-place proximal mapping for `f`, evaluated at `x`, with stepsize `gamma`.

--- a/src/ProximalCore.jl
+++ b/src/ProximalCore.jl
@@ -66,9 +66,9 @@ struct IndZero end
 function (::IndZero)(x)
     R = real(eltype(x))
     if iszero(x)
-        return R(Inf)
+        return R(0)
     end
-    return R(0)
+    return R(Inf)
 end
 
 is_convex(::Type{IndZero}) = true

--- a/src/ProximalCore.jl
+++ b/src/ProximalCore.jl
@@ -53,11 +53,6 @@ struct Zero end
 
 (::Zero)(x) = real(eltype(x))(0)
 
-function gradient!(y, f::Zero, x)
-    y .= eltype(x)(0)
-    return f(x)
-end
-
 function prox!(y, ::Zero, x, gamma)
     y .= x
     return real(eltype(y))(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,16 @@ end
         end
 
     end
+
+    @testset "Others" begin
+
+        @inferred (f -> Val(is_convex(f)))(42)
+        @inferred (f -> Val(is_generalized_quadratic(f)))(42)
+
+        @test !is_convex(42)
+        @test !is_generalized_quadratic(42)
+
+    end
     
     @testset "Conjugation" begin
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@ using Test
 using Aqua
 using LinearAlgebra
 using ProximalCore
-using ProximalCore: prox, gradient, convex_conjugate
-using ProximalCore: Zero, IndZero
-import ProximalCore: prox!, is_convex, is_generalized_quadratic
+using ProximalCore: prox, prox!
+using ProximalCore: Zero, IndZero, convex_conjugate
+import ProximalCore: is_convex, is_generalized_quadratic
 
 @testset "Aqua" begin
     Aqua.test_all(ProximalCore)
@@ -38,7 +38,6 @@ end
         for T in [Float32, Float64]
             @test let x = T[1.0, 2.0, 3.0]
                 prox(Zero(), x, T(42)) == (x, T(0))
-                gradient(Zero(), x) == (T[0, 0, 0], T(0))
             end
         end
         

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,9 +36,10 @@ end
         @test is_generalized_quadratic(Zero())
 
         for T in [Float32, Float64]
-            @test let x = T[1.0, 2.0, 3.0]
-                prox(Zero(), x, T(42)) == (x, T(0))
-            end
+            x = T[1.0, 2.0, 3.0]
+            @test Zero()(x) == T(0)
+            @test prox(Zero(), x, T(42)) == (x, T(0))
+            @test prox(Zero(), x, ) == (x, T(0))
         end
         
     end
@@ -52,9 +53,11 @@ end
         @test is_generalized_quadratic(IndZero())
 
         for T in [Float32, Float64]
-            @test let x = T[1.0, 2.0, 3.0]
-                prox(IndZero(), x, T(42)) == (T[0, 0, 0], T(0))
-            end
+            x = T[1.0, 2.0, 3.0]
+            @test IndZero()(x) == T(Inf)
+            @test IndZero()(T[0, 0, 0]) == T(0)
+            @test prox(IndZero(), x, T(42)) == (T[0, 0, 0], T(0))
+            @test prox(IndZero(), x) == (T[0, 0, 0], T(0))
         end
 
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,9 @@ using Test
 using Aqua
 using LinearAlgebra
 using ProximalCore
-using ProximalCore: prox, prox!
+using ProximalCore: prox
 using ProximalCore: Zero, IndZero, convex_conjugate
-import ProximalCore: is_convex, is_generalized_quadratic
+import ProximalCore: prox!, is_convex, is_generalized_quadratic
 
 @testset "Aqua" begin
     Aqua.test_all(ProximalCore)


### PR DESCRIPTION
The idea is to remove the gradient operation from the API that this package exposes. Reasons:
- it’s not always ideal to compute function value and gradient together, for example in line-search methods one usually wants to evaluate a bunch of function values only, and then a gradient at the end; a better interface would give f(x) and a closure to evaluate the gradient additionally (“backward pass”)
- this package and packages implementing the interface should be about proximal maps, as autodiff packages and interfaces exist that allow injecting all sorts of custom backward passes, and client packages should rely on those
- there no dependent on this package other than ProximalOperators and ProximalAlgorithms at the moment, so breaking now is essentially harm-free

Follow up plan:
- remove gradient computations from ProximalOperators
- bump dependency of ProximalAlgorithms on ProximalCore, update interface for gradient computation there 