### PR TITLE
Fix deploydocs call in make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,7 +13,4 @@ makedocs(
     ]
 )
 
-deploydocs(
-    repo = "github.com/JuliaFirstOrder/ProximalCore.jl",
-    devbranch = "main"
-)
+deploydocs(repo = "github.com/JuliaFirstOrder/ProximalCore.jl")


### PR DESCRIPTION
Generation of documentation was skipped because the optional field `devbranch` was set to "main" instead of "master". Deleting this keyword argument instructs Documenter.jl to figure out the correct branch name automatically.